### PR TITLE
feat: Change logic for generating the Dashboard UID and enable the user to override the UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ and in the [`README.md` of the Helm Chart`](./charts/grafaml/README.md).
 
 You can find example Dashboards in the [`example-dashboards`](./example-dashboards/) directory.
 
-In the next stept, the `values-my-dashboard.json` will be merged with the default [default `values.yaml`](./charts/grafaml/values.yaml),
+In the next step, the `values-my-dashboard.json` will be merged with the default [default `values.yaml`](./charts/grafaml/values.yaml),
 from which the dashboard JSON will be generated.
 
 ### Generating the dashboard JSON

--- a/charts/grafaml/README.md
+++ b/charts/grafaml/README.md
@@ -28,3 +28,4 @@ Find the full documentation at [Github](https://github.com/erNail/grafaml).
 | timepicker.enabled | bool | `false` | Wether the timepicker configuration is rendered or not.  |
 | timezone | string | `"browser"` | The timezone of the dashboard, either "utc" or "browser". Ref: [Grafana JSON Fields](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/#json-fields)  |
 | title | string | `"Grafana Dashboard"` | The displayed title of the Dashboard. Ref: [Grafana JSON Fields](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/#json-fields)  |
+| uidOverride | string | `""` | The unique identifier of the Dashboard. String value must be between 8 and 40 characters. Ref: [Grafana JSON Fields](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/#json-fields)  |

--- a/charts/grafaml/templates/_helpers.tpl
+++ b/charts/grafaml/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create a uid for the dashboard.
+The uid
+*/}}
+{{- define "grafaml.uid" -}}
+  {{- if .Values.uidOverride }}
+    {{- .Values.uidOverride }}
+  {{- else }}
+    {{- $uid := sha1sum (include "grafaml.fullname" .) }}
+    {{- $uid }}
+  {{- end }}
+{{- end }}

--- a/charts/grafaml/templates/configmap.yaml
+++ b/charts/grafaml/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
 
 {{- define "dashboardYaml" -}}
 title: "{{ .Values.title }}"
-uid: "{{ include "grafaml.fullname" . }}"
+uid: "{{ include "grafaml.uid" . }}"
 style: "{{ .Values.style }}"
 timezone: "{{ .Values.timezone }}"
 editable: "{{ .Values.editable }}"

--- a/charts/grafaml/templates/tests/validations.yaml
+++ b/charts/grafaml/templates/tests/validations.yaml
@@ -9,3 +9,8 @@
 {{- if not (or (eq (int .Values.graphTooltip) 0) (eq (int .Values.graphTooltip) 1) (eq (int .Values.graphTooltip) 2)) }}
   {{- fail "graphTooltip must be 0, 1 or 2." }}
 {{- end }}
+
+{{- $uid := include "grafaml.uid" . }}
+{{- if (or (lt (len $uid) 8) (gt (len $uid) 40)) }}
+  {{- fail "uid must be between 8 and 40 characters" }}
+{{- end }}

--- a/charts/grafaml/tests/configmap_test.yaml
+++ b/charts/grafaml/tests/configmap_test.yaml
@@ -2,11 +2,13 @@
 suite: "Test Configmap"
 templates:
   - "configmap.yaml"
+  - "tests/validations.yaml"
 release:
   name: "test-release"
   namespace: "test-namespace"
 tests:
   - it: "Should render ConfigMap with default values"
+    template: "configmap.yaml"
     asserts:
       - isKind:
           of: "ConfigMap"
@@ -17,6 +19,7 @@ tests:
           pattern: >-
             "title": "Grafana Dashboard"
   - it: "Should render ConfigMap with dashboard values 'values-node-dashboard.yaml'"
+    template: "configmap.yaml"
     values:
       - "../../../example-dashboards/values-node-dashboard.yaml"
     asserts:
@@ -29,6 +32,7 @@ tests:
           pattern: >-
             "title": "Node Dashboard"
   - it: "Should render ConfigMap with dashboard values 'values-simple-dashboard.yaml'"
+    template: "configmap.yaml"
     values:
       - "../../../example-dashboards/values-simple-dashboard.yaml"
     asserts:
@@ -42,6 +46,7 @@ tests:
             "title": "Simple Dashboard"
 
   - it: "Should only render the dashboard json if enabled"
+    template: "configmap.yaml"
     set:
       onlyRenderDashboardJson: true
     asserts:
@@ -53,12 +58,14 @@ tests:
           path: "editable"
 
   - it: "Should not render timepicker config with default values"
+    template: "configmap.yaml"
     asserts:
       - notMatchRegex:
           path: "data[\"test-release-grafaml.json\"]"
           pattern: >-
             "timepicker"
   - it: "Should render timepicker config if enabled"
+    template: "configmap.yaml"
     set:
       timepicker:
         enabled: true
@@ -79,12 +86,14 @@ tests:
               \s*[^}]*enable": true
 
   - it: "Should not render templating config with default values"
+    template: "configmap.yaml"
     asserts:
       - notMatchRegex:
           path: "data[\"test-release-grafaml.json\"]"
           pattern: >-
             "templating"
   - it: "Should render templating config if enabled"
+    template: "configmap.yaml"
     set:
       templating:
         enabled: true
@@ -96,12 +105,14 @@ tests:
               \s*[^}]*list":
 
   - it: "Should not render annotation config with default values"
+    template: "configmap.yaml"
     asserts:
       - notMatchRegex:
           path: "data[\"test-release-grafaml.json\"]"
           pattern: >-
             "annotations":
   - it: "Should render annotation config if enabled"
+    template: "configmap.yaml"
     set:
       annotations:
         enabled: true

--- a/charts/grafaml/tests/validations_test.yaml
+++ b/charts/grafaml/tests/validations_test.yaml
@@ -26,4 +26,18 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "graphTooltip must be 0, 1 or 2."
+
+  - it: "Should fail to render if uid has less than 8 characters"
+    set:
+      uidOverride: "uid"
+    asserts:
+      - failedTemplate:
+          errorMessage: "uid must be between 8 and 40 characters"
+
+  - it: "Should fail to render if uid has more than 40 characters"
+    set:
+      uidOverride: "this-is-a-very-long-uid-with-more-than-40-characters"
+    asserts:
+      - failedTemplate:
+          errorMessage: "uid must be between 8 and 40 characters"
 ...

--- a/charts/grafaml/values.yaml
+++ b/charts/grafaml/values.yaml
@@ -17,6 +17,11 @@ extraLabels:
 #
 title: "Grafana Dashboard"
 
+# -- The unique identifier of the Dashboard. String value must be between 8 and 40 characters.
+# Ref: [Grafana JSON Fields](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/#json-fields)
+#
+uidOverride: ""
+
 # -- The tags of the dashboard.
 # Ref: [Grafana JSON Fields](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/#json-fields)
 #


### PR DESCRIPTION
Since the grafaml.fullname function is used in the configmap for setting the UID of the JSON dashboard I adjusted the trunc to 40. UIDs greater than 40 are not accepted by grafana which leads to successful configmap deployment but no implementation of the grafana dashboard.

Alternatively the setting of the uid value would have to be changed from the grafana.fullname function to an entirely different helpers function or a value being set in the values.yaml which in turn could then be checked in the validation.yaml for char count <= 40.